### PR TITLE
Empty.js Should return an object

### DIFF
--- a/tables/empty.js
+++ b/tables/empty.js
@@ -168,7 +168,7 @@ class OuterbasePluginTableConfiguration_$PLUGIN_ID extends HTMLElement {
         saveButton.addEventListener("click", () => {
             this.callCustomEvent({
                 action: 'onsave',
-                value: true
+                value: this.config
             })
         });
     }


### PR DESCRIPTION
Was playing around with plugins and noticed that empty.js didn't save a valid config. There's a few other files in the examples that don't save with an object but a boolean. Just wanted to try and pitch in really quick.

Resolves #6 